### PR TITLE
Adds Boto profile argument for multiple credential support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,13 +64,16 @@ And materialize it into AWS EC2 accordingly.
 Command line tool ::
 
     Usage:
-      ec2yaml <conf> [(--key=<key> --secret=<secret>)] [--loglevel=<level>]
+    ec2yaml <conf> [(--key=<key> --secret=<secret>)\
+    | --boto-profile=<boto-profile>]\
+    [--loglevel=<level>]
 
     Options:
-      -h --help              Show this screen.
-      -v --version           Show version.
-      -k --key=<key>         AWS access key ID
-      -s --secret=<secret>   AWS secret access key
-      -l --loglevel=<level>  Log level to display [default: info]
+      -h --help                           Show this screen.
+      -v --version                        Show version.
+      -k --key=<key>                      AWS access key ID
+      -s --secret=<secret>                AWS secret access key
+      -bp --boto-profile=<boto-profile>   Boto Profile Name
+      -l --loglevel=<level>               Log level to display [default: info]
 
 

--- a/ec2yaml/actions.py
+++ b/ec2yaml/actions.py
@@ -25,11 +25,16 @@ def initialize_with_conf(conf):
     create_application_security_group(conn, conf['app']['name'])
 
     for key, value in conf['instances'].iteritems():
-        value['security_groups'].append(conf['app']['name'])
+        if 'security_groups' in value:
+            value['security_groups'].append(conf['app']['name'])
 
     instances_with_conf(conn, conf)
-    assign_ips_with_conf(conf)
-    assign_volumes_with_conf(conf)
+
+    if 'elastic_ips' in conf:
+        assign_ips_with_conf(conf)
+
+    if 'volumes' in conf:
+        assign_volumes_with_conf(conf)
 
 
 def initialize_with_string(string):

--- a/ec2yaml/cli.py
+++ b/ec2yaml/cli.py
@@ -1,14 +1,17 @@
 '''ec2yaml.
 
 Usage:
-  ec2yaml <conf> [(--key=<key> --secret=<secret>)] [--loglevel=<level>]
+  ec2yaml <conf> [(--key=<key> --secret=<secret>)]\
+  [--boto-profile=<boto-profile>]\
+  [--loglevel=<level>]
 
 Options:
-  -h --help              Show this screen.
-  -v --version           Show version.
-  -k --key=<key>         AWS access key ID
-  -s --secret=<secret>   AWS secret access key
-  -l --loglevel=<level>  Log level to display [default: info]
+  -h --help                           Show this screen.
+  -v --version                        Show version.
+  -k --key=<key>                      AWS access key ID
+  -s --secret=<secret>                AWS secret access key
+  -bp --boto-profile=<boto-profile>   Boto Profile Name
+  -l --loglevel=<level>               Log level to display [default: info]
 '''
 import logging
 from docopt import docopt
@@ -29,10 +32,14 @@ def _init_conf(args):
 
     key = args.get('--key', None)
     secret = args.get('--secret', None)
+    boto_profile = args.get('--boto-profile', None)
 
-    if key and secret in args:
+    if key and secret:
         conf['app']['key'] = key
         conf['app']['secret'] = secret
+
+    if boto_profile:
+        conf['app']['boto_profile'] = boto_profile
 
     return conf
 

--- a/ec2yaml/utils.py
+++ b/ec2yaml/utils.py
@@ -8,7 +8,9 @@ __CONNECTION__ = None
 
 def connection(
         location='us-west-2',
-        aws_access_key_id=None, aws_secret_access_key=None):
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
+        profile_name=None):
 
     global __CONNECTION__
 
@@ -18,6 +20,9 @@ def connection(
             log.debug('Using provided \'aws_access_key_id\''
                       ' and \'aws_secret_access_key\'.'
                       '\nNot loading from environment variables.')
+        elif profile_name:
+            log.debug('Using provided \'profile_name\''
+                      '\nLoading from boto profile specified by boto-profile.')
         else:
             log.debug('Using provided \'AWS_ACCESS_KEY_ID\''
                       ' and \'AWS_SECRET_ACCESS_KEY\''
@@ -26,7 +31,8 @@ def connection(
         __CONNECTION__ = boto.ec2.connect_to_region(
             location,
             aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key
+            aws_secret_access_key=aws_secret_access_key,
+            profile_name=profile_name
         )
 
     return __CONNECTION__
@@ -36,11 +42,13 @@ def connection_from_config(conf):
     location = conf['app'].get('location', 'us-east-1')
     key = conf['app'].get('key', None)
     secret = conf['app'].get('secret', None)
+    boto_profile = conf['app'].get('boto_profile', None)
 
     return connection(
         location=location,
         aws_access_key_id=key,
-        aws_secret_access_key=secret)
+        aws_secret_access_key=secret,
+        profile_name=boto_profile)
 
 
 def key_for_group(item):


### PR DESCRIPTION
Reference:
http://boto.readthedocs.org/en/latest/boto_config_tut.html#credentials

Usage:

```
ec2yaml --boto-profile Personal test.yaml
```

Where "Personal" is defined in `.boto` as:

```
[profile Personal]
aws_access_key_id = <access key for this profile>
aws_secret_access_key = <secret key for this profile>
```
